### PR TITLE
simple_server.py path issues

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ cd ~/temp/boost_1_76_0
 ./bootstrap.sh --with-python=/usr/bin/python3
 sudo ./b2 --with-python install
 cd ~/temp
-wget https://ftp.wayne.edu/apache//xerces/c/3/sources/xerces-c-3.2.3.tar.gz
+wget https://dlcdn.apache.org//xerces/c/3/sources/xerces-c-3.2.4.zip
 tar -xf xerces-c-3.2.3.tar.gz
 cd xerces-c-3.2.3 && ./configure --prefix=/usr && make && sudo make install
 cd

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ cd ~/temp/boost_1_76_0
 ./bootstrap.sh --with-python=/usr/bin/python3
 sudo ./b2 --with-python install
 cd ~/temp
-wget https://dlcdn.apache.org//xerces/c/3/sources/xerces-c-3.2.4.zip
+wget https://dlcdn.apache.org//xerces/c/3/sources/xerces-c-3.2.4.tar.gz
 tar -xf xerces-c-3.2.4.tar.gz
 cd xerces-c-3.2.4 && ./configure --prefix=/usr && make && sudo make install
 cd

--- a/setup.sh
+++ b/setup.sh
@@ -18,8 +18,8 @@ cd ~/temp/boost_1_76_0
 sudo ./b2 --with-python install
 cd ~/temp
 wget https://dlcdn.apache.org//xerces/c/3/sources/xerces-c-3.2.4.zip
-tar -xf xerces-c-3.2.3.tar.gz
-cd xerces-c-3.2.3 && ./configure --prefix=/usr && make && sudo make install
+tar -xf xerces-c-3.2.4.tar.gz
+cd xerces-c-3.2.4 && ./configure --prefix=/usr && make && sudo make install
 cd
 rm -rf ~/temp
 sudo apt update -y


### PR DESCRIPTION
### Issue Description:
****
simple_server script throws an issue error when compiled.
```
Traceback (most recent call last):
  File "./scripts/simple_server.py", line 47, in <module>
    ssl_ctx.load_cert_chain(certfile=ROOT + '/root-ca/server.crt', keyfile=ROOT + '/root-ca/private/server.key')

FileNotFoundError: [Errno 2] No such file or directory
```

### Branch:
****
Cloned the main Branch.

### Edited File:
****
**/dtm/scripts/simple_server.py**

### Solving the error attempt:
****
The error is addressed by adding the following lines:
```
os.chdir('..')
```
And 
```
ROOT = str(Path.csd()))
```
